### PR TITLE
Nuxt 3 Starter Kit

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@ If you want to contribute to this list, then please read the [contributing guide
 
 ## Starter Kits
 - [SurrealDB + SvelteKit Starter](https://github.com/spinspire/surrealdb-sveltekit-starter) - Jitesh Doshi.
+- [Nuxt Starter](https://github.com/dvanmali/surrealdb-nuxt-starter) - Dylan Vanmali.
 
 ## Tutorials
 - [Hosting Surreal DB in Rust in Less Than 3 Minutes](https://www.youtube.com/watch?v=VoRoeL1tal4) - Gui Bibeau.


### PR DESCRIPTION
A simple Nuxt 3 starter kit application. https://github.com/dvanmali/surrealdb-nuxt-starter

If you have an existing Nuxt 3 project setup, a server-side [Nitro Plugin](https://github.com/dvanmali/surrealdb-nuxt-starter/blob/main/server/plugins/surrealdb.ts) can be copied over to your existing project.