### PR TITLE
Add nextjs tauri kit in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ If you want to contribute to this list, then please read the [contributing guide
 
 ## Starter Kits
 - [SurrealDB + SvelteKit Starter](https://github.com/spinspire/surrealdb-sveltekit-starter) - Jitesh Doshi.
-- [Starter Kit for SurrealDB + Tauri + Next.js](https://github.com/reymom/surrealdb-starter-taurikit) - reymom.
+- [Starter Kit for SurrealDB + Tauri + Next.js](https://github.com/reymom/surrealdb-starter-taurikit) - Reymom.
 
 ## Tutorials
 - [Hosting Surreal DB in Rust in Less Than 3 Minutes](https://www.youtube.com/watch?v=VoRoeL1tal4) - Gui Bibeau.

--- a/README.md
+++ b/README.md
@@ -137,6 +137,7 @@ If you want to contribute to this list, then please read the [contributing guide
 
 ## Starter Kits
 - [SurrealDB + SvelteKit Starter](https://github.com/spinspire/surrealdb-sveltekit-starter) - Jitesh Doshi.
+- [Starter Kit for SurrealDB + Tauri + Next.js](https://github.com/reymom/surrealdb-starter-taurikit) - reymom.
 
 ## Tutorials
 - [Hosting Surreal DB in Rust in Less Than 3 Minutes](https://www.youtube.com/watch?v=VoRoeL1tal4) - Gui Bibeau.


### PR DESCRIPTION
My contribution for the issue [#35](https://github.com/surrealdb/awesome-surreal/issues/35).

From the [README.md](https://github.com/reymom/surrealdb-starter-taurikit#readme): This starter kit provides a streamlined setup for developing a Tauri App + Next.js applications with an integrated [SurrealDB](https://surrealdb.com/) database. It bridges the frontend with the backend using an ICP command layer following the JSON-RPC 2.0 format.

If there's something that should be improved, do let me know :+1: 