### PR TITLE
Add flask starter kit app

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,7 @@ If you want to contribute to this list, then please read the [contributing guide
 ## Starter Kits
 - [SurrealDB + SvelteKit Starter](https://github.com/spinspire/surrealdb-sveltekit-starter) - Jitesh Doshi.
 - [SurrealDB + SolidStart Starter](https://github.com/metruzanca/surreal-solid-template) - Sam "metru" Zanca.
+- [SurrealDB + Flask Starter](https://github.com/syedzubeen/surrealdb_flask_starter_app) - Syed Zubeen
 
 ## Tutorials
 - [Hosting Surreal DB in Rust in Less Than 3 Minutes](https://www.youtube.com/watch?v=VoRoeL1tal4) - Gui Bibeau.

--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ If you want to contribute to this list, then please read the [contributing guide
 ## Starter Kits
 - [SurrealDB + SvelteKit Starter](https://github.com/spinspire/surrealdb-sveltekit-starter) - Jitesh Doshi.
 - [SurrealDB + SolidStart Starter](https://github.com/metruzanca/surreal-solid-template) - Sam "metru" Zanca.
-- [SurrealDB + Flask Starter](https://github.com/syedzubeen/surrealdb_flask_starter_app) - Syed Zubeen
+- [SurrealDB + Flask Starter](https://github.com/syedzubeen/surrealdb_flask_starter_app) - Syed Zubeen.
 
 ## Tutorials
 - [Hosting Surreal DB in Rust in Less Than 3 Minutes](https://www.youtube.com/watch?v=VoRoeL1tal4) - Gui Bibeau.


### PR DESCRIPTION
Adding the Flask starter kit for SurrealDB for issue #35 

Starter-Kit URL: https://github.com/syedzubeen/surrealdb_flask_starter_app

This is a very basic app that has a simple signup page and inserts records into the person tab of the test1 db inside the test1 namespace. I have tried to keep it very simple for users to get started quickly.