### PR TITLE
Add SurrealDB Sandbox

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,3 +164,4 @@ If you want to contribute to this list, then please read the [contributing guide
 - [Nextjs + surrealdb demo](https://github.com/kearfy/demo-nextjs-surrealdb) - Basic blog that serves as a demo / template for your nextjs + surrealdb project.
 - [Pandorica](https://github.com/omnilium/pandorica) - FOSS zero-knowledge secure file storage.
 - [Playrbase](https://github.com/theopensource-company/playrbase) - Event & player management system.
+- [SurrealDB Sandbox](https://github.com/plasmatech8/surrealdb-sandbox) - An offline browser-based playground for experimenting with SurrealDB.


### PR DESCRIPTION
SurrealDB Sandbox is a simple offline browser-based playground for SurrealDB.

* [Github Repo](https://github.com/plasmatech8/surrealdb-sandbox)
* [Live Demo](https://surrealdb-sandbox.pages.dev/)
* [Reddit post](https://www.reddit.com/r/surrealdb/comments/17c1y0d/surrealdb_sandbox_an_offline_inbrowser_playground/)