### PR TITLE
Added Rocket Starter Kit

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,7 @@ If you want to contribute to this list, then please read the [contributing guide
 - [Starter Kit for SurrealDB + Tauri + Next.js](https://github.com/reymom/surrealdb-starter-taurikit) - Reymom.
 - [SurrealDB + Streamlit Starter](https://github.com/LuciAkirami/surrealdb-streamlit-starter-kit) - Lucifer Akirami.
 - [SurrealDB + Vue Starter](https://github.com/inkollusireeshaadharani/vue-starter-kit) - Dharani Inkollu.
+- [SurrealDB + Rocket](https://github.com/davidzr/surrealdb-rocket-starter) - David Zabala.
 
 ## Tutorials
 - [Hosting Surreal DB in Rust in Less Than 3 Minutes](https://www.youtube.com/watch?v=VoRoeL1tal4) - Gui Bibeau.


### PR DESCRIPTION
Added Rocket Starter Kit  #35

This is a simple project template that combines the [Rocket](https://rocket.rs/) web framework in Rust with SurrealDB,

[https://github.com/davidzr/surrealdb-rocket-starter](https://github.com/davidzr/surrealdb-rocket-starter)