### PR TITLE
docs: SurrealDB multicluster deployment on GCP using terraform

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ If you want to contribute to this list, then please read the [contributing guide
 ## Deployment tools
 - [Dokku Surrealdb](https://github.com/IgnisDa/dokku-surrealdb) - A plugin to deploy SurrealDB as a [Dokku](https://dokku.com) plugin.
 - [Pterodactyl Egg](https://github.com/Stefanuk12/Pterodactyl/blob/master/eggs/misc/egg-surrealdb.json) - An egg to deploy SurrealDB for the [Pterodactyl Panel](https://pterodactyl.io/).
+- [GKE using Terraform](https://github.com/dvanmali/terraform-google-surrealdb) - Multicluster Cross-Regional Deployment using GKE Autopilot and [Terraform](https://www.terraform.io/)
 
 ## Docker images
 [surrealdb/surrealdb](https://hub.docker.com/r/surrealdb/surrealdb) - <a href="https://surrealdb.com#gh-dark-mode-only" target="_blank"><img src="/img/white/text.svg" height="12" alt="SurrealDB"></a> <a href="https://surrealdb.com#gh-light-mode-only" target="_blank"><img src="/img/black/text.svg" height="12" alt="SurrealDB"></a> official Docker image.


### PR DESCRIPTION
An internal, multi-regional deployment of SurrealDB on multiple private GKE Autopilot clusters.

Setup currently includes:
- HTTPS using Google-managed SSL Certificate for the load balancer frontend (SSL-terminated) 
- IAP Jump Hosts for private managing
- Global private geo-based DNS routing

----

- [X] *Requires* Merge in Helm Chart Repo [#4](https://github.com/surrealdb/helm-charts/pull/4)
- [X] Close pull request [372](https://github.com/surrealdb/www.surrealdb.com/pull/372)